### PR TITLE
fix a typo in EN 'Terms of Use' string

### DIFF
--- a/i18n/en/design-system.json
+++ b/i18n/en/design-system.json
@@ -32,7 +32,7 @@
   "global-footer-site-overview-link-api": "API",
   "global-footer-site-overview-link-global-sitemap": "Global Sitemap",
   "global-footer-site-overview-link-local-sitemap": "Local Sitemap",
-  "global-footer-site-overview-link-terms-of-use": "Terms Of Use",
+  "global-footer-site-overview-link-terms-of-use": "Terms of Use",
   "global-footer-site-overview-link-privacy-policy": "Privacy Policy",
   "global-footer-licensing-and-vertical-description": "__sitename__ is a Fandom __vertical__ Community. Content is available under __license__.",
   "global-footer-licensing-and-vertical-description-param-vertical-tv": "TV",


### PR DESCRIPTION
Prepositions should not be capitalised. The string is also lowercased in the mockups.

@Wikia/x-wing 
