### PR TITLE
fix broken message in German language

### DIFF
--- a/i18n/en/design-system.json
+++ b/i18n/en/design-system.json
@@ -33,7 +33,7 @@
   "global-footer-site-overview-link-local-sitemap": "Local Sitemap",
   "global-footer-site-overview-link-terms-of-use": "Terms of Use",
   "global-footer-site-overview-link-privacy-policy": "Privacy Policy",
-  "global-footer-licensing-and-vertical-description": "__sitename__ is a FANDOM __vertical__ Community. Content is available under __license__.",
+  "global-footer-licensing-and-vertical-description": "__sitename__ is a FANDOM __- vertical__ Community. Content is available under __license__.",
   "global-footer-licensing-and-vertical-description-param-vertical-tv": "TV",
   "global-footer-licensing-and-vertical-description-param-vertical-games": "Games",
   "global-footer-licensing-and-vertical-description-param-vertical-books": "Books",


### PR DESCRIPTION
it disabled escaping of the variable but it's disabled anyway in the configuration
but this way i18next properly parses var name

anyone remember why we went with __?
I think I am going to propose that we move away from it toward ICU {} format that [formatjs](https://formatjs.io/guides/message-syntax/) uses

Left to do: 

- [ ] Upload to crowdin
- [ ] Redownload messages from crowdin